### PR TITLE
Delete Key Fix

### DIFF
--- a/src/default.coffee
+++ b/src/default.coffee
@@ -14,6 +14,7 @@ KEY_CODE =
   DOWN:40
   BACKSPACE: 8
   SPACE: 32
+  DELETE: 46
 
 # Functions set for handling and rendering the data.
 # Others developers can override these methods to tweak At.js such as matcher.

--- a/src/editableController.coffee
+++ b/src/editableController.coffee
@@ -38,6 +38,15 @@ class EditableController extends Controller
     return unless range = @_getRange()
     return unless range.collapsed
 
+    # Check inserts for disparity on Backspace and delete
+    if e.which in [KEY_CODE.BACKSPACE, KEY_CODE.DELETE]
+      @$inputor.find('[data-atwho-chosen-value]')
+        .each () ->
+          console.log "Wre are compareking \"" + $(this).text() + "\" and \"" + $(this).attr('data-atwho-chosen-value') + "\""
+          if $(this).text() != $(this).attr('data-atwho-chosen-value')
+            $(this).remove()
+      return
+
     if e.which == KEY_CODE.ENTER
       ($query = $(range.startContainer).closest '.atwho-query')
         .contents().unwrap()
@@ -74,7 +83,10 @@ class EditableController extends Controller
       .addClass 'atwho-query'
       .siblings().removeClass 'atwho-query'
 
-    if ($query = $ ".atwho-query", @app.document).length > 0 \
+    $query = $ range.startContainer
+      .closest '.atwho-query'
+
+    if $query.length > 0 \
         and $query.is(':empty') and $query.text().length == 0
       $query.remove()
       return
@@ -88,10 +100,7 @@ class EditableController extends Controller
 
     if $query.length > 0 and query_content = $query.text()
       chosen = $query.attr('data-atwho-chosen-value')
-      if e.which = KEY_CODE.BACKSPACE
-        $query.remove()
-        return
-      else if chosen and query_content != chosen
+      if chosen and query_content != chosen
         # $query.empty().html(query_content).attr('data-atwho-chosen-value', null)
         $query.before(query_content).remove()
         return


### PR DESCRIPTION
Delete key now works. Both the backspace and delete keys now take a higher priority, triggering a content disparity check each time they are pressed. The changes in #5 were required for the fix, and so they are included in this PR.
